### PR TITLE
Make integration test independent from local timezone + fix error logging message missmatch between wirtten and read data

### DIFF
--- a/integration-testing/clickhouse/writeReadEquality.sql
+++ b/integration-testing/clickhouse/writeReadEquality.sql
@@ -1,7 +1,7 @@
 CREATE TABLE writeReadEqualityTable
 (
-    `dateTime` DateTime,
-    `dateTimeNullable` Nullable(DateTime),
+    `dateTime` DateTime('UTC'),
+    `dateTimeNullable` Nullable(DateTime('UTC')),
     `int128` Int128,
     `int128Nullable` Nullable(Int128),
     `int16` Int16,

--- a/integration-testing/lib/IntegrationTests/WriteReadEquality.hs
+++ b/integration-testing/lib/IntegrationTests/WriteReadEquality.hs
@@ -87,8 +87,8 @@ runTest client = do
 
   (when (head result /= testData) . error)
     (  testLabel <> "Unequal result.\n"
-    <> "Writed data: " <> show (head result) <> "\n"
-    <> "Readed data: " <> show testData)
+    <> "Writed data: " <> show testData <> "\n"
+    <> "Readed data: " <> show (head result))
 
   print $ testLabel <> "Ok"
 


### PR DESCRIPTION
1. Fixed reverse position of written and read data in the error text.
2. Added UTC parameter for DateTime values in test Table creation script.